### PR TITLE
Update to AKS 1.21.2 and reduce NTP firewall rule

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -103,7 +103,7 @@
         }
     },
     "variables": {
-        "kubernetesVersion": "1.21.1",
+        "kubernetesVersion": "1.21.2",
 
         "networkContributorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7')]",
         "monitoringMetricsPublisherRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb')]",

--- a/cluster-stamp.v2.json
+++ b/cluster-stamp.v2.json
@@ -103,7 +103,7 @@
         }
     },
     "variables": {
-        "kubernetesVersion": "1.21.1",
+        "kubernetesVersion": "1.21.2",
 
         "networkContributorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7')]",
         "monitoringMetricsPublisherRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb')]",

--- a/networking/hub-region.v2.json
+++ b/networking/hub-region.v2.json
@@ -660,10 +660,9 @@
                             "rules": [
                                 {
                                     "name": "ntp",
-                                    "description": "Network Time Protocol (NTP) time synchronization for image builder VMs, nodepool nodes, and jumpboxes.",
+                                    "description": "Network Time Protocol (NTP) time synchronization for image builder VMs and jumpboxes.",
                                     "sourceIpGroups": [
                                         "[resourceId('Microsoft.Network/ipGroups', variables('imageBuilderIpGroupName'))]",
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]",
                                         "[resourceId('Microsoft.Network/ipGroups', variables('aksJumpBoxIpGroupName'))]"
                                     ],
                                     "protocols": [
@@ -672,12 +671,9 @@
                                     "destinationPorts": [
                                         "123"
                                     ],
-                                    "destinationAddresses": [
-                                        "*"
-                                    ]/*,
                                     "destinationFqdns": [
                                         "ntp.ubuntu.com"
-                                    ]*/
+                                    ]
                                 }
                             ]
                         }


### PR DESCRIPTION
* Update to AKS 1.21.2 (from 1.21.1)
* Remove the node pool firewall allocation for NTP
* revert back to ntp.ubuntu.com for firewall rule