### PR TITLE
Force disable public DNS for Private Cluster

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1223,7 +1223,7 @@
         },
         {
             "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2021-03-01",
+            "apiVersion": "2021-05-01",
             "name": "[variables('clusterName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -1432,7 +1432,8 @@
                 },*/
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": true,
-                    "privateDNSZone": "[resourceId(variables('vNetResourceGroup'), 'Microsoft.Network/privateDnsZones', concat('privatelink.', parameters('location') ,'.azmk8s.io'))]"
+                    "privateDNSZone": "[resourceId(variables('vNetResourceGroup'), 'Microsoft.Network/privateDnsZones', concat('privatelink.', parameters('location') ,'.azmk8s.io'))]",
+                    "enablePrivateClusterPublicFQDN": false
                 },
                 "podIdentityProfile": { 
                     "enabled": true

--- a/cluster-stamp.v2.json
+++ b/cluster-stamp.v2.json
@@ -1223,7 +1223,7 @@
         },
         {
             "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2021-03-01",
+            "apiVersion": "2021-05-01",
             "name": "[variables('clusterName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -1432,7 +1432,8 @@
                 },*/
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": true,
-                    "privateDNSZone": "[resourceId(variables('vNetResourceGroup'), 'Microsoft.Network/privateDnsZones', concat('privatelink.', parameters('location') ,'.azmk8s.io'))]"
+                    "privateDNSZone": "[resourceId(variables('vNetResourceGroup'), 'Microsoft.Network/privateDnsZones', concat('privatelink.', parameters('location') ,'.azmk8s.io'))]",
+                    "enablePrivateClusterPublicFQDN": false
                 },
                 "podIdentityProfile": { 
                     "enabled": true,

--- a/docs/deploy/01-prerequisites.md
+++ b/docs/deploy/01-prerequisites.md
@@ -25,7 +25,7 @@ Throughout this walkthrough, take note of the following symbol.
 
 1. Latest [Azure CLI installed](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) or you can perform this from Azure Cloud Shell by clicking below.
 
-   [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
+   [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/hdi-launch-cloud-shell.png)](https://shell.azure.com/bash)
 
    Ensure you're logged into the subscription in which you plan on deploying this reference to.
 

--- a/docs/deploy/05-networking-hub.md
+++ b/docs/deploy/05-networking-hub.md
@@ -19,7 +19,7 @@ The examples that follow use `eastus2` as the primary region. You're welcome to 
 * Regional Hubs are allocated to `10.200.[0-9].0` in this reference implementation. The `eastus2` hub (created below) will be `10.200.0.0/24`.
 * Regional Spokes (created later) in this reference implementation are allocated to `10.240.0.0/16` and `10.241.0.0/28`.
 
-Since this reference implementation is expected to be deployed isolated from existing infrastructure and not joined to any of your existing networks; these IP addresses should not come in conflict with any existing networking you have, even if those IP addresses overlap with ones you already have. However, if you need to join existing networks, even for this walkthrough, you'll need to adjust the IP space as per your requirements as to not conflict in the reference ARM templates.
+Since this walkthrough is expected to be deployed isolated from existing infrastructure and not joined to any of your existing networks; these IP addresses should not come in conflict with any existing networking you have, even if those IP addresses overlap with ones you already have. However, if you need to join existing networks, even for the purposes this walkthrough, you'll need to adjust the IP space in the ARM templates as per your requirements as to not conflict.
 
 ## Steps
 


### PR DESCRIPTION
* Be explicit about no public DNS record for the private cluster
* Updated the Cloud Shell button to be the latest and force that the user starts in BASH not PowerShell (feedback from hackathon)
* Minor wording update to remove possible confusion around IP address conflicts