### PR TITLE
Fix PDB and new HTTPS Ingress Policy rule

### DIFF
--- a/docs/deploy/11-gitops.md
+++ b/docs/deploy/11-gitops.md
@@ -111,13 +111,13 @@ Your GitHub repo will be the source of truth for your cluster's configuration. T
 
    ```output
    NAME                                  STATUS   ROLES   AGE   VERSION
-   aks-npinscope01-26621167-vmss000000   Ready    agent   20m   v1.20.5
-   aks-npinscope01-26621167-vmss000001   Ready    agent   20m   v1.20.5
-   aks-npooscope01-26621167-vmss000000   Ready    agent   20m   v1.20.5
-   aks-npooscope01-26621167-vmss000001   Ready    agent   20m   v1.20.5
-   aks-npsystem-26621167-vmss000000      Ready    agent   20m   v1.20.5
-   aks-npsystem-26621167-vmss000001      Ready    agent   20m   v1.20.5
-   aks-npsystem-26621167-vmss000002      Ready    agent   20m   v1.20.5
+   aks-npinscope01-26621167-vmss000000   Ready    agent   20m   v1.21.x
+   aks-npinscope01-26621167-vmss000001   Ready    agent   20m   v1.21.x
+   aks-npooscope01-26621167-vmss000000   Ready    agent   20m   v1.21.x
+   aks-npooscope01-26621167-vmss000001   Ready    agent   20m   v1.21.x
+   aks-npsystem-26621167-vmss000000      Ready    agent   20m   v1.21.x
+   aks-npsystem-26621167-vmss000001      Ready    agent   20m   v1.21.x
+   aks-npsystem-26621167-vmss000002      Ready    agent   20m   v1.21.x
    ```
 
    > :watch: The access tokens obtained in the prior two steps are subject to a Microsoft Identity Platform TTL (e.g. six hours). If your `az` or `kubectl` commands start erroring out after hours of usage with a message related to permission/authorization, you'll need to re-execute the `az login` and `az aks get-credentials` (overwriting your context) to refresh those tokens.

--- a/workload/a0005-i/microservice-c/deployment.yaml
+++ b/workload/a0005-i/microservice-c/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         kubernetes.io/os: linux
         pci-scope: in-scope
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: microservice-c

--- a/workload/a0005-i/web-frontend/deployment.yaml
+++ b/workload/a0005-i/web-frontend/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         kubernetes.io/os: linux
         pci-scope: in-scope
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: web-frontend

--- a/workload/a0005-i/web-frontend/ingress.yaml
+++ b/workload/a0005-i/web-frontend/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   tls:
   - hosts:

--- a/workload/a0005-o/microservice-a/deployment.yaml
+++ b/workload/a0005-o/microservice-a/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         kubernetes.io/os: linux
         pci-scope: out-of-scope
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: microservice-a

--- a/workload/a0005-o/microservice-b/deployment.yaml
+++ b/workload/a0005-o/microservice-b/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         kubernetes.io/os: linux
         pci-scope: out-of-scope
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: microservice-b


### PR DESCRIPTION
* Update PDBs to v1 from v1beta for 1.21
* Update the output that shows Kubernetes version numbers to 1.21 from 1.20
* Require HTTPS ingress now has another condition for nginx, added.