### PR TITLE
OSM: Switch from config map (0.8.x) to MeshConfig (0.9.x)

### DIFF
--- a/cluster-manifests/kube-system/osm-config.yaml
+++ b/cluster-manifests/kube-system/osm-config.yaml
@@ -1,15 +1,26 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: config.openservicemesh.io/v1alpha1
+kind: MeshConfig
 metadata:
-  name: osm-config
-data:
-  permissive_traffic_policy_mode: "false"
-  egress: "true"
-  enable_privileged_init_container: "false"
-  envoy_log_level: warn
-  enable_debug_server: "false"
-  outbound_ip_range_exclusion_list: 169.254.169.254/32,168.63.129.16/32,10.240.12.4/32
-  prometheus_scraping: "true"
-  tracing_enable: "false"
-  use_https_ingress: "true"
-  service_cert_validity_duration: "24h"
+  name: osm-mesh-config
+spec:
+  certificate:
+    serviceCertValidityDuration: 24h
+  featureFlags:
+    enableEgressPolicy: true
+    enableWASMStats: false
+  observability:
+    enableDebugServer: false
+    osmLogLevel: info
+    tracing:
+      enable: false
+  sidecar:
+    enablePrivilegedInitContainer: false
+    logLevel: error
+  traffic:
+    enableEgress: true
+    enablePermissiveTrafficPolicyMode: false
+    outboundIPRangeExclusionList:
+      - 169.254.169.254/32
+      - 168.63.129.16/32
+      - 10.240.12.4/32
+    useHTTPSIngress: true


### PR DESCRIPTION
* OSM is now configured via a custom CRD in 0.9.x, migrate to that CRD instead of ConfigMap