### PR TITLE
Ingress Controller: Add Metrics & Update Query

### DIFF
--- a/cluster-manifests/ingress-nginx/deployment.yaml
+++ b/cluster-manifests/ingress-nginx/deployment.yaml
@@ -273,6 +273,9 @@ spec:
   minReadySeconds: 0
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
@@ -345,6 +348,9 @@ spec:
               protocol: TCP
             - name: webhook
               containerPort: 8443
+              protocol: TCP
+            - name: metrics
+              containerPort: 10254
               protocol: TCP
           volumeMounts:
             - name: webhook-cert

--- a/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
+++ b/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
@@ -24,7 +24,7 @@ data:
     [prometheus_data_collection_settings.cluster]
         interval = "1m"
         monitor_kubernetes_pods = true
-        monitor_kubernetes_pods_namespaces = ["a0005-i", "a0005-o", "cluster-baseline-settings", "flux-system", "falco-system", "ingress-nginx", "osm-system"]
+        monitor_kubernetes_pods_namespaces = ["a0005-i", "a0005-o", "cluster-baseline-settings", "flux-system", "falco-system", "ingress-nginx"]
     [prometheus_data_collection_settings.node]
         interval = "1m"
         urls = ["http://$NODE_IP:9103/metrics"]

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -885,7 +885,7 @@
                         "eTag": "*",
                         "category": "Prometheus",
                         "displayName": "Increase number of forbidden response on the Ingress Controller",
-                        "query": "let value = toscalar(InsightsMetrics | where Namespace == \"prometheus\" and Name == \"traefik_entrypoint_requests_total\" | where parse_json(Tags).code == 403 | summarize Value = avg(Val) by bin(TimeGenerated, 5m) | summarize min = min(Value)); InsightsMetrics | where Namespace == \"prometheus\" and Name == \"traefik_entrypoint_requests_total\" | where parse_json(Tags).code == 403 | summarize AggregatedValue = avg(Val)-value by bin(TimeGenerated, 5m) | order by TimeGenerated | render barchart",
+                        "query": "let value = toscalar(InsightsMetrics | where Namespace == \"prometheus\" and Name == \"nginx_ingress_controller_requests\" | where parse_json(Tags).status == 403 | summarize Value = avg(Val) by bin(TimeGenerated, 5m) | summarize min = min(Value)); InsightsMetrics | where Namespace == \"prometheus\" and Name == \"nginx_ingress_controller_requests\" | where parse_json(Tags).status == 403 | summarize AggregatedValue = avg(Val)-value by bin(TimeGenerated, 5m) | order by TimeGenerated | render barchart",
                         "version": 1
                     }
                 },

--- a/cluster-stamp.v2.json
+++ b/cluster-stamp.v2.json
@@ -885,7 +885,7 @@
                         "eTag": "*",
                         "category": "Prometheus",
                         "displayName": "Increase number of forbidden response on the Ingress Controller",
-                        "query": "let value = toscalar(InsightsMetrics | where Namespace == \"prometheus\" and Name == \"traefik_entrypoint_requests_total\" | where parse_json(Tags).code == 403 | summarize Value = avg(Val) by bin(TimeGenerated, 5m) | summarize min = min(Value)); InsightsMetrics | where Namespace == \"prometheus\" and Name == \"traefik_entrypoint_requests_total\" | where parse_json(Tags).code == 403 | summarize AggregatedValue = avg(Val)-value by bin(TimeGenerated, 5m) | order by TimeGenerated | render barchart",
+                        "query": "let value = toscalar(InsightsMetrics | where Namespace == \"prometheus\" and Name == \"nginx_ingress_controller_requests\" | where parse_json(Tags).status == 403 | summarize Value = avg(Val) by bin(TimeGenerated, 5m) | summarize min = min(Value)); InsightsMetrics | where Namespace == \"prometheus\" and Name == \"nginx_ingress_controller_requests\" | where parse_json(Tags).status == 403 | summarize AggregatedValue = avg(Val)-value by bin(TimeGenerated, 5m) | order by TimeGenerated | render barchart",
                         "version": 1
                     }
                 },


### PR DESCRIPTION
This PR does the following:
* Adds Prometheus metrics collection on the ingress controller
* Updates the Log Analytics query that used to be pulling Traefik metrics. This Fixes #26.
* Remove old `osm-system` namespace (from pre-addon days) from OMS agent config.

Tested as functioning.