### PR TITLE
Allow Virtual Network Gateways in the hub resource group

### DIFF
--- a/subscription.json
+++ b/subscription.json
@@ -503,6 +503,7 @@
                                             "Microsoft.Network/networkSecurityGroups",
                                             "Microsoft.Network/networkSecurityGroups/securityRules",
                                             "Microsoft.Network/publicIpAddresses",
+                                            "Microsoft.Network/virtualNetworkGateways",
                                             "Microsoft.Network/virtualNetworks",
                                             "Microsoft.Network/virtualNetworks/subnets",
                                             "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",


### PR DESCRIPTION
While we don't use them in this RI, the hub is designed to accept virtual network gateways (we have a subnet for them afterall).  Allowing it for a bit more realism.