### PR TITLE
AKS regulated - hubs Firewall fixes

### DIFF
--- a/networking/hub-region.v0.json
+++ b/networking/hub-region.v0.json
@@ -600,15 +600,7 @@
                         "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
                         "logs": [
                             {
-                                "category": "AzureFirewallApplicationRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallNetworkRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallDnsProxy",
+                                "categoryGroup": "allLogs",
                                 "enabled": true
                             }
                         ],

--- a/networking/hub-region.v1.json
+++ b/networking/hub-region.v1.json
@@ -729,6 +729,7 @@
                                         }
                                     ],
                                     "targetFqdns": [
+                                        "objects.githubusercontent.com",
                                         "storage.googleapis.com",
                                         "api.github.com",
                                         "github-releases.githubusercontent.com",
@@ -823,15 +824,7 @@
                         "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
                         "logs": [
                             {
-                                "category": "AzureFirewallApplicationRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallNetworkRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallDnsProxy",
+                                "categoryGroup": "allLogs",
                                 "enabled": true
                             }
                         ],

--- a/networking/hub-region.v2.json
+++ b/networking/hub-region.v2.json
@@ -864,6 +864,7 @@
                                         }
                                     ],
                                     "targetFqdns": [
+                                        "objects.githubusercontent.com",
                                         "storage.googleapis.com",
                                         "api.github.com",
                                         "github-releases.githubusercontent.com",
@@ -1056,15 +1057,7 @@
                         "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
                         "logs": [
                             {
-                                "category": "AzureFirewallApplicationRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallNetworkRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallDnsProxy",
+                                "categoryGroup": "allLogs",
                                 "enabled": true
                             }
                         ],


### PR DESCRIPTION
1) Usage of  "categoryGroup": "allLogs" in Azure FW Diagnostic Settings

2) When running install-k8scli, "objects.githubusercontent.com" Fqdns should be allowed

