### PR TITLE
Sync with Jump Box migration to Bicep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.pem
 *.pub
 sp.json
+
+jumpbox/**/*.bicep

--- a/docs/deploy/06-aks-jumpboximage.md
+++ b/docs/deploy/06-aks-jumpboximage.md
@@ -65,7 +65,7 @@ Now that we have our image building network created, egressing through our hub, 
    Ideally core templates like this would be part of your private Bicep registry. For this walk through, we are simply downloading the remote Bicep templates locally for execution.
 
    ```bash
-   wget -B https://raw.githubusercontent.com/mspnp/aks-jumpbox-imagebuilder/bicep-migration/ -x -nH --cut-dirs=3 -i jumpbox/jumpbox-bicep.txt -P jumpbox
+   wget -B https://raw.githubusercontent.com/mspnp/aks-jumpbox-imagebuilder/main/ -x -nH --cut-dirs=3 -i jumpbox/jumpbox-bicep.txt -P jumpbox
    ```
 
 1. Deploy custom Azure RBAC roles. _Optional._
@@ -88,7 +88,7 @@ Now that we have our image building network created, egressing through our hub, 
    ROLEID_IMGDEPLOY=$(az deployment sub show -n DeployAibRbacRoles --query 'properties.outputs.roleResourceIds.value.customImageBuilderImageCreationRole.guid' -o tsv)
 
    # [This takes about one minute to run.]
-   az deployment group create -g rg-bu0001a0005 -f jumpbox/deploy.bicep -p buildInSubnetResourceId=${RESOURCEID_SUBNET_AIB} location=eastus2 imageBuilderNetworkingRoleGuid="${ROLEID_NETWORKING}" imageBuilderImageCreationRoleGuid="${ROLEID_IMGDEPLOY}" -n CreateJumpBoxImageTemplate
+   az deployment group create -g rg-bu0001a0005 -f jumpbox/azuredeploy.bicep -p buildInSubnetResourceId=${RESOURCEID_SUBNET_AIB} location=eastus2 imageBuilderNetworkingRoleGuid="${ROLEID_NETWORKING}" imageBuilderImageCreationRoleGuid="${ROLEID_IMGDEPLOY}" -n CreateJumpBoxImageTemplate
    ```
 
 1. Build the general-purpose AKS jump box image.

--- a/jumpbox/jumpbox-bicep.txt
+++ b/jumpbox/jumpbox-bicep.txt
@@ -1,0 +1,4 @@
+createsubscriptionroles.bicep
+deploy.bicep
+modules/aibImageWriteRoleAssignment.bicep
+modules/aibNetworkRoleAssignment.bicep

--- a/jumpbox/jumpbox-bicep.txt
+++ b/jumpbox/jumpbox-bicep.txt
@@ -1,4 +1,4 @@
 createsubscriptionroles.bicep
-deploy.bicep
+azuredeploy.bicep
 modules/aibImageWriteRoleAssignment.bicep
 modules/aibNetworkRoleAssignment.bicep


### PR DESCRIPTION
The Jumpbox image builder repo is switching to bicep, integrating that change into this readme.

No functional changes, just procedural ones.

This will go live in conjunction with mspnp/aks-jumpbox-imagebuilder#13.