### PR TITLE
Updates for `az ad` breaking changes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to the AKS Secure Baseline Reference Implementation
+# Contributing to the AKS Baseline for Regulated Industries Reference Implementation
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com/>.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Azure Kubernetes Service (AKS) Baseline Cluster for Regulated Workloads
 
-This reference implementation demonstrates the _recommended starting (baseline) infrastructure architecture_ for an [AKS cluster](https://azure.microsoft.com/services/kubernetes-service) that is under regulatory compliance requirements (such as PCI). This implementation builds directly upon the [AKS Baseline Cluster reference implementation](https://github.com/mspnp/aks-secure-baseline) and adds to it additional implementation points that are more commonly seen in regulated environments vs typical "public cloud" consumption patterns.
+This reference implementation demonstrates the _recommended starting (baseline) infrastructure architecture_ for an [AKS cluster](https://azure.microsoft.com/services/kubernetes-service) that is under regulatory compliance requirements (such as PCI). This implementation builds directly upon the [AKS Baseline Cluster reference implementation](https://github.com/mspnp/aks-baseline) and adds to it additional implementation points that are more commonly seen in regulated environments vs typical "public cloud" consumption patterns.
 
 | 🎓 Foundational Understanding |
 |:------------------------------|
-| **If you haven't familiarized yourself with the general-purpose [AKS baseline cluster](https://github.com/mspnp/aks-secure-baseline) architecture, you should start there before continuing here.** This architecture is constructed from the AKS baseline, which is the foundation for this body of work. This reference implementation avoids rearticulating points that are already addressed in the AKS baseline cluster. |
+| **If you haven't familiarized yourself with the general-purpose [AKS baseline cluster](https://github.com/mspnp/aks-baseline) architecture, you should start there before continuing here.** This architecture is constructed from the AKS baseline, which is the foundation for this body of work. This reference implementation avoids rearticulating points that are already addressed in the AKS baseline cluster. |
 
 ## Compliance
 

--- a/docs/deploy/01-prerequisites.md
+++ b/docs/deploy/01-prerequisites.md
@@ -23,7 +23,7 @@ Throughout this walkthrough, take note of the following symbol.
 
    The Azure AD tenant backing your Cluster's API RBAC does NOT need to be the same tenant associated with your Azure subscription. Your organization may have dedicated Azure AD tenants used specifically as a separation between Azure resource management, and Kubernetes control plane access. Ensure you're following your organization's practices when it comes to separation of identity stores to ensure limited "blast radius" on any compromised accounts.
 
-1. Latest [Azure CLI installed](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) or you can perform this from Azure Cloud Shell by clicking below.
+1. Latest [Azure CLI installed](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) (must be at least 2.37), or you can perform this from Azure Cloud Shell by clicking below.
 
    [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/hdi-launch-cloud-shell.png)](https://shell.azure.com/bash)
 

--- a/docs/deploy/03-aad.md
+++ b/docs/deploy/03-aad.md
@@ -42,7 +42,7 @@ Following the steps below will result in an Azure AD configuration that will be 
 
    ```bash
    AADOBJECTNAME_GROUP_CLUSTERADMIN=cluster-admins-bu0001a000500
-   AADOBJECTID_GROUP_CLUSTERADMIN=$(az ad group create --display-name $AADOBJECTNAME_GROUP_CLUSTERADMIN --mail-nickname $AADOBJECTNAME_GROUP_CLUSTERADMIN --description "Principals in this group are cluster admins in the bu0001a000500 cluster." --query objectId -o tsv)
+   AADOBJECTID_GROUP_CLUSTERADMIN=$(az ad group create --display-name $AADOBJECTNAME_GROUP_CLUSTERADMIN --mail-nickname $AADOBJECTNAME_GROUP_CLUSTERADMIN --description "Principals in this group are cluster admins in the bu0001a000500 cluster." --query id -o tsv)
    ```
 
 1. Create a "break-glass" cluster administrator user for your AKS cluster.
@@ -52,7 +52,7 @@ Following the steps below will result in an Azure AD configuration that will be 
    ```bash
    TENANTDOMAIN_K8SRBAC=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv | cut -d '@' -f 2 | sed 's/\"//')
    AADOBJECTNAME_USER_CLUSTERADMIN=bu0001a000500-admin
-   AADOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${AADOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${AADOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-login --password ChangeMebu0001a0005AdminChangeMe --query objectId -o tsv)
+   AADOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${AADOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${AADOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-sign-in --password ChangeMebu0001a0005AdminChangeMe --query id -o tsv)
    ```
 
 1. Add the cluster admin user(s) to the cluster admin security group.

--- a/docs/deploy/13-validation-logs.md
+++ b/docs/deploy/13-validation-logs.md
@@ -4,7 +4,7 @@ Your infrastructure and [workload is emitting logs](./13-validation.md), here ar
 
 You can access these logs all directly from the attached Log Analytics workspace(s), but when you do you'll need to filter to specific resources. For simplicity the steps below direct you to the pre-filtered view offered by the Azure Portal when viewing within the context of each service.
 
-Remember, since this implementation builds on the AKS Baseline, [validations performed there](https://github.com/mspnp/aks-secure-baseline/blob/main/10-validation.md#validate-azure-monitor-for-containers-prometheus-metrics) such as viewing Prometheus metrics and Kured logs are also applicable to this cluster.
+Remember, since this implementation builds on the AKS Baseline, [validations performed there](https://github.com/mspnp/aks-baseline/blob/main/11-validation.md#validate-azure-monitor-for-containers-prometheus-metrics) such as viewing Prometheus metrics and Kured logs are also applicable to this cluster.
 
 ## Azure Firewall
 


### PR DESCRIPTION
`az ad` and `az role` are now Microsoft Graph-based (instead of Azure AD Graph-based), which means some of the results are different than they were before. This brings this implementation in line with the latest.

Changes: https://docs.microsoft.com/cli/azure/microsoft-graph-migration

Also:

* fixed a broken link to the AKS baseline
* cleaned up the URLs to the AKS baseline (old to new value)