### PR TITLE
feat (cluster): [upgrade version] cluster to the latest k8s supported version (v1.23 to v1.25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Finally, this implementation uses a small, custom application as an example work
 
 #### Azure platform
 
-* AKS v1.23
+* AKS v1.25
   * System and User [node pool separation](https://learn.microsoft.com/azure/aks/use-system-pools)
   * [AKS-managed Azure AD](https://learn.microsoft.com/azure/aks/managed-aad)
   * Managed Identities for kubelet and control plane

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -1218,6 +1218,9 @@ resource mc 'Microsoft.ContainerService/managedClusters@2022-10-02-preview' = {
     podIdentityProfile: {
       enabled: false
     }
+    autoUpgradeProfile: {
+      upgradeChannel: 'stable'
+    }
     disableLocalAccounts: true
     securityProfile: {
       workloadIdentity: {

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -1320,9 +1320,9 @@ resource crMiKubeletContainerRegistryPullRole_roleAssignment 'Microsoft.Authoriz
   }
 }
 
-@description('Grant OMS agent managed identity with publisher metrics role permissions; this allows the OMS agent\'s identity to publish metrics in Container Insights.')
-resource sMiOmsMonitoringMetricPublisherRoleRole_roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(mc.id, monitoringMetricsPublisherRole.id)
+@description('Grant Azure Monitor (fka as OMS) Agent\'s managed identity with publisher metrics role permissions; this allows the AMA\'s identity to publish metrics in Container Insights.')
+resource mcAmaAgentMonitoringMetricsPublisherRole_roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mc.id, 'amagent', monitoringMetricsPublisherRole.id)
   properties: {
     roleDefinitionId: monitoringMetricsPublisherRole.id
     principalId: mc.properties.addonProfiles.omsagent.identity.objectId

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -1039,6 +1039,7 @@ resource mc 'Microsoft.ContainerService/managedClusters@2022-10-02-preview' = {
         osDiskSizeGB: 80
         osDiskType: 'Ephemeral'
         osType: 'Linux'
+        osSKU: 'Ubuntu'
         minCount: 3
         maxCount: 4
         vnetSubnetID: vnetSpoke::snetClusterSystemNodePools.id
@@ -1072,6 +1073,7 @@ resource mc 'Microsoft.ContainerService/managedClusters@2022-10-02-preview' = {
         osDiskSizeGB: 120
         osDiskType: 'Ephemeral'
         osType: 'Linux'
+        osSKU: 'Ubuntu'
         minCount: 2
         maxCount: 5
         vnetSubnetID: vnetSpoke::snetClusterInScopeNodePools.id

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -1020,7 +1020,7 @@ module ensureClusterIdentityHasRbacToSelfManagedResources 'modules/ensureCluster
   }
 }
 
-resource mc 'Microsoft.ContainerService/managedClusters@2022-08-03-preview' = {
+resource mc 'Microsoft.ContainerService/managedClusters@2022-10-02-preview' = {
   name: clusterName
   location: location
   tags: {

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -54,7 +54,7 @@ param gitOpsBootstrappingRepoBranch string = 'main'
 
 /*** VARIABLES ***/
 
-var kubernetesVersion = '1.25.4'
+var kubernetesVersion = '1.25.2'
 
 var subRgUniqueString = uniqueString('aks', subscription().subscriptionId, resourceGroup().id)
 var clusterName = 'aks-${subRgUniqueString}'

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -54,7 +54,7 @@ param gitOpsBootstrappingRepoBranch string = 'main'
 
 /*** VARIABLES ***/
 
-var kubernetesVersion = '1.23.12'
+var kubernetesVersion = '1.25.4'
 
 var subRgUniqueString = uniqueString('aks', subscription().subscriptionId, resourceGroup().id)
 var clusterName = 'aks-${subRgUniqueString}'

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -142,7 +142,7 @@ Once web traffic hits Azure Application Gateway (deployed in a future step), pub
 
    ```bash
    KEYVAULT_NAME=$(az deployment group show --resource-group rg-bu0001a0005 -n pre-cluster-stamp --query properties.outputs.keyVaultName.value -o tsv)
-   TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT=$(az role assignment create --role a4417e6f-fecd-4de8-b567-7b0420556985 --assignee-principal-type user --assignee-object-id $(az ad signed-in-user show --query 'id' -o tsv) --scope $(az keyvault show --name $KEYVAULT_NAME --query 'id' -o tsv) --query 'id' -o tsv)
+   TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT=$(az role assignment create --role a4417e6f-fecd-4de8-b567-7b0420556985 --assignee-principal-type user --assignee-object-id $(az ad signed-in-user show --query 'objectId' -o tsv) --scope $(az keyvault show --name $KEYVAULT_NAME --query 'id' -o tsv) --query 'id' -o tsv)
    echo TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT: $TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT
 
    # If you are behind a proxy or some other egress that does not provide a consistent IP, you'll need to manually adjust the

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -74,7 +74,7 @@ Using a security agent that is container-aware and can operate from within the c
    # Get your quarantine Azure Container Registry service name
    # You only deployed one ACR instance in this walkthrough, but this could be
    # a separate, dedicated quarantine instance managed by your IT team.
-   ACR_NAME_QUARANTINE=$(az deployment group show -g rg-bu0001a0005 -n -n pre-cluster-stamp --query properties.outputs.quarantineContainerRegistryName.value -o tsv)
+   ACR_NAME_QUARANTINE=$(az deployment group show -g rg-bu0001a0005 -n pre-cluster-stamp --query properties.outputs.quarantineContainerRegistryName.value -o tsv)
 
    # [Combined this takes about eight minutes.]
    az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE               && \
@@ -108,7 +108,7 @@ Using a security agent that is container-aware and can operate from within the c
 
    ```bash
    # Get your live Azure Container Registry service name
-   ACR_NAME=$(az deployment group show -g rg-bu0001a0005 -n -n pre-cluster-stamp --query properties.outputs.containerRegistryName.value -o tsv)
+   ACR_NAME=$(az deployment group show -g rg-bu0001a0005 -n pre-cluster-stamp --query properties.outputs.containerRegistryName.value -o tsv)
 
    # [Combined this takes about eight minutes.]
    az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME                 && \

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -142,7 +142,7 @@ Once web traffic hits Azure Application Gateway (deployed in a future step), pub
 
    ```bash
    KEYVAULT_NAME=$(az deployment group show --resource-group rg-bu0001a0005 -n pre-cluster-stamp --query properties.outputs.keyVaultName.value -o tsv)
-   TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT=$(az role assignment create --role a4417e6f-fecd-4de8-b567-7b0420556985 --assignee-principal-type user --assignee-object-id $(az ad signed-in-user show --query 'objectId' -o tsv) --scope $(az keyvault show --name $KEYVAULT_NAME --query 'id' -o tsv) --query 'id' -o tsv)
+   TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT=$(az role assignment create --role a4417e6f-fecd-4de8-b567-7b0420556985 --assignee-principal-type user --assignee-object-id $(az ad signed-in-user show --query 'id' -o tsv) --scope $(az keyvault show --name $KEYVAULT_NAME --query 'id' -o tsv) --query 'id' -o tsv)
    echo TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT: $TEMP_ROLEASSIGNMENT_TO_UPLOAD_CERT
 
    # If you are behind a proxy or some other egress that does not provide a consistent IP, you'll need to manually adjust the

--- a/docs/deploy/11-validate-cluster-access-and-bootstrapping.md
+++ b/docs/deploy/11-validate-cluster-access-and-bootstrapping.md
@@ -71,13 +71,13 @@ Your cluster was deployed with Azure Policy and the Flux GitOps extension. You'l
 
    ```output
    NAME                                  STATUS   ROLES   AGE   VERSION
-   aks-npinscope01-26621167-vmss000000   Ready    agent   20m   v1.23.x
-   aks-npinscope01-26621167-vmss000001   Ready    agent   20m   v1.23.x
-   aks-npooscope01-26621167-vmss000000   Ready    agent   20m   v1.23.x
-   aks-npooscope01-26621167-vmss000001   Ready    agent   20m   v1.23.x
-   aks-npsystem-26621167-vmss000000      Ready    agent   20m   v1.23.x
-   aks-npsystem-26621167-vmss000001      Ready    agent   20m   v1.23.x
-   aks-npsystem-26621167-vmss000002      Ready    agent   20m   v1.23.x
+   aks-npinscope01-26621167-vmss000000   Ready    agent   20m   v1.25.x
+   aks-npinscope01-26621167-vmss000001   Ready    agent   20m   v1.25.x
+   aks-npooscope01-26621167-vmss000000   Ready    agent   20m   v1.25.x
+   aks-npooscope01-26621167-vmss000001   Ready    agent   20m   v1.25.x
+   aks-npsystem-26621167-vmss000000      Ready    agent   20m   v1.25.x
+   aks-npsystem-26621167-vmss000001      Ready    agent   20m   v1.25.x
+   aks-npsystem-26621167-vmss000002      Ready    agent   20m   v1.25.x
    ```
 
    > :watch: The access tokens obtained in the prior two steps are subject to a Microsoft Identity Platform TTL (e.g. six hours). If your `az` or `kubectl` commands start erroring out after hours of usage with a message related to permission/authorization, you'll need to re-execute the `az login` and `az aks get-credentials` (overwriting your context) to refresh those tokens.


### PR DESCRIPTION
closes: #23808

## WHY

we want to bump the regulated AKS cluster to the latest GA(ed) version to keep our baselines up to date.

## WHAT Changed?

- bump AKS Version from 1.24 to 1.25
- additional hardening like upgrade to stable
- naming convention change for OMS to be aligned with latest changes and baseline.
- other minors

## HOW to Test?

as a user you can clone and execute the document steps to deploy a new AKS cluster using the latest version.