### PR TITLE
feat (in-cluster infra): [upgrade oss] bump kured to 1.12.0 and azm cfg

### DIFF
--- a/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
+++ b/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
@@ -120,10 +120,10 @@ spec:
           # PRODUCTION READINESS CHANGE REQUIRED
           # This image should be sourced from a non-public container registry, such as the
           # one deployed along side of this reference implementation.
-          # az acr import --source docker.io/weaveworks/kured:1.12.0 -n <your-acr-instance-name>
+          # az acr import --source ghcr.io/kubereboot/kured:1.12.0 -n <your-acr-instance-name>
           # and then set this to
           # image: <your-acr-instance-name>.azurecr.io/weaveworks/kured:1.12.0
-          image: docker.io/weaveworks/kured:1.12.0
+          image: ghcr.io/kubereboot/kured:1.12.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true # Give permission to nsenter /proc/1/ns/mnt

--- a/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
+++ b/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
@@ -15,7 +15,10 @@ rules:
   verbs:     ["get", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs:     ["list", "delete", "get"]
+  verbs:     ["list","delete","get"]
+- apiGroups: ["extensions"]
+  resources: ["daemonsets"]
+  verbs:     ["get"]
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
   verbs:     ["get"]
@@ -42,11 +45,15 @@ metadata:
   namespace: cluster-baseline-settings
   name: kured
 rules:
-# Allow kured to lock/unlock itself
-- apiGroups:     ["apps"]
-  resources:     ["daemonsets"]
-  resourceNames: ["kured"]
-  verbs:         ["update"]
+  # Allow kured to lock/unlock itself
+  - apiGroups:     ["extensions"]
+    resources:     ["daemonsets"]
+    resourceNames: ["kured"]
+    verbs:         ["update", "patch"]
+  - apiGroups:     ["apps"]
+    resources:     ["daemonsets"]
+    resourceNames: ["kured"]
+    verbs:         ["update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -76,14 +83,16 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: kured
+      app.kubernetes.io/name: kured
       pci-scope: out-of-scope
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
-        name: kured
+        app.kubernetes.io/name: kured
         pci-scope: out-of-scope
       annotations:
         prometheus.io/scrape: "true"
@@ -92,12 +101,15 @@ spec:
     spec:
       serviceAccountName: kured
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         - key: CriticalAddonsOnly
           effect: NoSchedule
           operator: Equal
           value: "true"
+      hostNetwork: true
       hostPID: true # Facilitate entering the host mount namespace via init
       restartPolicy: Always
       nodeSelector:
@@ -113,6 +125,8 @@ spec:
           # image: <your-acr-instance-name>.azurecr.io/weaveworks/kured:1.12.0
           image: docker.io/weaveworks/kured:1.12.0
           imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true # Give permission to nsenter /proc/1/ns/mnt
           resources:
             limits:
               cpu: 500m
@@ -120,8 +134,9 @@ spec:
             requests:
               cpu: 200m
               memory: 16Mi
-          securityContext:
-            privileged: true # Give permission to nsenter /proc/1/ns/mnt
+          ports:
+            - containerPort: 8080
+              name: metrics
           env:
             - name: KURED_NODE_ID
               valueFrom:
@@ -129,6 +144,7 @@ spec:
                   fieldPath: spec.nodeName
           command:
             - /usr/bin/kured
+          args:
             - --ds-namespace=cluster-baseline-settings
 #            - --force-reboot=false
 #            - --drain-grace-period=-1

--- a/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
+++ b/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
@@ -122,7 +122,7 @@ spec:
           # one deployed along side of this reference implementation.
           # az acr import --source ghcr.io/kubereboot/kured:1.12.0 -n <your-acr-instance-name>
           # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/weaveworks/kured:1.12.0
+          # image: <your-acr-instance-name>.azurecr.io/kubereboot/kured:1.12.0
           image: ghcr.io/kubereboot/kured:1.12.0
           imagePullPolicy: IfNotPresent
           securityContext:

--- a/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
+++ b/cluster-manifests/cluster-baseline-settings/kured/kured.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/weaveworks/kured/releases/download/1.9.2/kured-1.9.2-dockerhub.yaml
+# Source: https://github.com/kubereboot/charts/tree/kured-4.2.0/charts/kured (1.12.0)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -108,10 +108,10 @@ spec:
           # PRODUCTION READINESS CHANGE REQUIRED
           # This image should be sourced from a non-public container registry, such as the
           # one deployed along side of this reference implementation.
-          # az acr import --source docker.io/weaveworks/kured:1.9.2 -n <your-acr-instance-name>
+          # az acr import --source docker.io/weaveworks/kured:1.12.0 -n <your-acr-instance-name>
           # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/weaveworks/kured:1.9.2
-          image: docker.io/weaveworks/kured:1.9.2
+          # image: <your-acr-instance-name>.azurecr.io/weaveworks/kured:1.12.0
+          image: docker.io/weaveworks/kured:1.12.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-manifests/cluster-baseline-settings/kustomization.yaml
+++ b/cluster-manifests/cluster-baseline-settings/kustomization.yaml
@@ -13,5 +13,5 @@ images:
 - name: busybox
   newName: REPLACE_ME_WITH_YOUR_ACRNAME.azurecr.io/live/library/busybox
   newTag: 1.33.0
-- name: docker.io/weaveworks/kured
-  newName: REPLACE_ME_WITH_YOUR_ACRNAME.azurecr.io/live/weaveworks/kured
+- name: ghcr.io/kubereboot/kured
+  newName: REPLACE_ME_WITH_YOUR_ACRNAME.azurecr.io/live/kubereboot/kured

--- a/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
+++ b/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
@@ -40,7 +40,7 @@ data:
           enabled = true
        [log_collection_settings.enrich_container_logs]
           # In the absense of this configmap, default value for enrich_container_logs is false
-          enabled = false
+          enabled = true
           # When this is enabled (enabled = true), every container log entry (both stdout & stderr) will be enriched with container Name & container Image
        [log_collection_settings.collect_all_kube_events]
           # In the absense of this configmap, default value for collect_all_kube_events is false

--- a/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
+++ b/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
@@ -24,7 +24,7 @@ data:
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stdout' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system"]
+          exclude_namespaces = []
 
        [log_collection_settings.stderr]
           # Default value for enabled is true
@@ -33,7 +33,7 @@ data:
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system"]
+          exclude_namespaces = []
 
        [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true

--- a/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
+++ b/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
@@ -2,48 +2,186 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: container-azm-ms-agentconfig
+  namespace: kube-system
 data:
   # https://raw.githubusercontent.com/microsoft/Docker-Provider/ci_prod/kubernetes/container-azm-ms-agentconfig.yaml
-  schema-version: v1
-  config-version: ver1
+  # https://learn.microsoft.com/azure/azure-monitor/containers/container-insights-agent-config
+  schema-version:
+    #string.used by agent to parse config. supported versions are {v1}. Configs with other schema versions will be rejected by the agent.
+    v1
+  config-version:
+    #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
+    ver1
   log-data-collection-settings: |-
+    # Log data collection settings
+    # Any errors related to config map settings can be found in the KubeMonAgentEvents table in the Log Analytics workspace that the cluster is sending data to.
+
     [log_collection_settings]
        [log_collection_settings.stdout]
+          # In the absense of this configmap, default value for enabled is true
           enabled = true
-          exclude_namespaces = []
+          # exclude_namespaces setting holds good only if enabled is set to true
+          # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stdout' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
+          # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
+          # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
+          exclude_namespaces = ["kube-system","gatekeeper-system"]
+
        [log_collection_settings.stderr]
+          # Default value for enabled is true
           enabled = true
-          exclude_namespaces = []
+          # exclude_namespaces setting holds good only if enabled is set to true
+          # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
+          # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
+          # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
+          exclude_namespaces = ["kube-system","gatekeeper-system"]
+
        [log_collection_settings.env_var]
+          # In the absense of this configmap, default value for enabled is true
           enabled = true
        [log_collection_settings.enrich_container_logs]
-          enabled = true
-       [log_collection_settings.collect_all_kube_events]
+          # In the absense of this configmap, default value for enrich_container_logs is false
           enabled = false
+          # When this is enabled (enabled = true), every container log entry (both stdout & stderr) will be enriched with container Name & container Image
+       [log_collection_settings.collect_all_kube_events]
+          # In the absense of this configmap, default value for collect_all_kube_events is false
+          # When the setting is set to false, only the kube events with !normal event type will be collected
+          enabled = false
+          # When this is enabled (enabled = true), all kube events including normal events will be collected
+       [log_collection_settings.schema]
+          # In the absence of this configmap, default value for containerlog_schema_version is "v1"
+          # Supported values for this setting are "v1","v2"
+          # See documentation at https://aka.ms/ContainerLogv2 for benefits of v2 schema over v1 schema before opting for "v2" schema
+          containerlog_schema_version = "v2"
+
   prometheus-data-collection-settings: |-
+    # Custom Prometheus metrics data collection settings
     [prometheus_data_collection_settings.cluster]
+        # Cluster level scrape endpoint(s). These metrics will be scraped from agent's Replicaset (singleton)
+        # Any errors related to prometheus scraping can be found in the KubeMonAgentEvents table in the Log Analytics workspace that the cluster is sending data to.
+
+        #Interval specifying how often to scrape for metrics. This is duration of time and can be specified for supporting settings by combining an integer value and time unit as a string value. Valid time units are ns, us (or µs), ms, s, m, h.
         interval = "1m"
+
+        ## Uncomment the following settings with valid string arrays for prometheus scraping
+        #fieldpass = ["metric_to_pass1", "metric_to_pass12"]
+
+        #fielddrop = ["metric_to_drop"]
+
+        # An array of urls to scrape metrics from.
+        # urls = ["http://myurl:9101/metrics"]
+
+        # An array of Kubernetes services to scrape metrics from.
+        # kubernetes_services = ["http://my-service-dns.my-namespace:9102/metrics"]
+
+        # When monitor_kubernetes_pods = true, replicaset will scrape Kubernetes pods for the following prometheus annotations:
+        # - prometheus.io/scrape: Enable scraping for this pod
+        # - prometheus.io/scheme: If the metrics endpoint is secured then you will need to
+        #     set this to `https` & most likely set the tls config.
+        # - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
+        # - prometheus.io/port: If port is not 9102 use this annotation
         monitor_kubernetes_pods = true
+
+        ## Restricts Kubernetes monitoring to namespaces for pods that have annotations set and are scraped using the monitor_kubernetes_pods setting.
+        ## This will take effect when monitor_kubernetes_pods is set to true
+        ##   ex: monitor_kubernetes_pods_namespaces = ["default1", "default2", "default3"]
         monitor_kubernetes_pods_namespaces = ["a0005-i", "a0005-o", "cluster-baseline-settings", "flux-system", "falco-system", "ingress-nginx"]
+
+        ## Label selector to target pods which have the specified label
+        ## This will take effect when monitor_kubernetes_pods is set to true
+        ## Reference the docs at https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        # kubernetes_label_selector = "env=dev,app=nginx"
+
+        ## Field selector to target pods which have the specified field
+        ## This will take effect when monitor_kubernetes_pods is set to true
+        ## Reference the docs at https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+        ## eg. To scrape pods on a specific node
+        # kubernetes_field_selector = "spec.nodeName=$HOSTNAME"
+
     [prometheus_data_collection_settings.node]
+        # Node level scrape endpoint(s). These metrics will be scraped from agent's DaemonSet running in every node in the cluster
+        # Any errors related to prometheus scraping can be found in the KubeMonAgentEvents table in the Log Analytics workspace that the cluster is sending data to.
+
+        #Interval specifying how often to scrape for metrics. This is duration of time and can be specified for supporting settings by combining an integer value and time unit as a string value. Valid time units are ns, us (or µs), ms, s, m, h.
         interval = "1m"
+
+        ## Uncomment the following settings with valid string arrays for prometheus scraping
+
+        # An array of urls to scrape metrics from. $NODE_IP (all upper case) will substitute of running Node's IP address
         urls = ["http://$NODE_IP:9103/metrics"]
+        #fieldpass = ["metric_to_pass1", "metric_to_pass12"]
+
+        #fielddrop = ["metric_to_drop"]
+
   metric_collection_settings: |-
+    # Metrics collection settings for metrics sent to Log Analytics and MDM
     [metric_collection_settings.collect_kube_system_pv_metrics]
-        enabled = true
+       # In the absense of this configmap, default value for collect_kube_system_pv_metrics is false
+       # When the setting is set to false, only the persistent volume metrics outside the kube-system namespace will be collected
+       # When this is enabled (enabled = true), persistent volume metrics including those in the kube-system namespace will be collected
+       enabled = true
+
   alertable-metrics-configuration-settings: |-
+    # Alertable metrics configuration settings for container resource utilization
     [alertable_metrics_configuration_settings.container_resource_utilization_thresholds]
+        # The threshold(Type Float) will be rounded off to 2 decimal points
+        # Threshold for container cpu, metric will be sent only when cpu utilization exceeds or becomes equal to the following percentage
         container_cpu_threshold_percentage = 90.0
+        # Threshold for container memoryRss, metric will be sent only when memory rss exceeds or becomes equal to the following percentage
         container_memory_rss_threshold_percentage = 90.0
+        # Threshold for container memoryWorkingSet, metric will be sent only when memory working set exceeds or becomes equal to the following percentage
         container_memory_working_set_threshold_percentage = 90.0
+
+    # Alertable metrics configuration settings for persistent volume utilization
     [alertable_metrics_configuration_settings.pv_utilization_thresholds]
+        # Threshold for persistent volume usage bytes, metric will be sent only when persistent volume utilization exceeds or becomes equal to the following percentage
         pv_usage_threshold_percentage = 75.0
+
+    # Alertable metrics configuration settings for completed jobs count
     [alertable_metrics_configuration_settings.job_completion_threshold]
+        # Threshold for completed job count , metric will be sent only for those jobs which were completed earlier than the following threshold
         job_completion_threshold_time_minutes = 360
   integrations: |-
     [integrations.azure_network_policy_manager]
         collect_basic_metrics = true
         collect_advanced_metrics = false
+    [integrations.azure_subnet_ip_usage]
+        enabled = true
+
+# Doc - https://github.com/microsoft/Docker-Provider/blob/ci_prod/Documentation/AgentSettings/ReadMe.md
   agent-settings: |-
+    # prometheus scrape fluent bit settings for high scale
+    # buffer size should be greater than or equal to chunk size else we set it to chunk size.
+    # settings scoped to prometheus sidecar container. all values in mb
+    [agent_settings.prometheus_fbit_settings]
+      tcp_listener_chunk_size = 10
+      tcp_listener_buffer_size = 10
+      tcp_listener_mem_buf_limit = 200
+
+    # prometheus scrape fluent bit settings for high scale
+    # buffer size should be greater than or equal to chunk size else we set it to chunk size.
+    # settings scoped to daemonset container. all values in mb
+    # [agent_settings.node_prometheus_fbit_settings]
+      # tcp_listener_chunk_size = 1
+      # tcp_listener_buffer_size = 1
+      # tcp_listener_mem_buf_limit = 10
+
+    # prometheus scrape fluent bit settings for high scale
+    # buffer size should be greater than or equal to chunk size else we set it to chunk size.
+    # settings scoped to replicaset container. all values in mb
+    # [agent_settings.cluster_prometheus_fbit_settings]
+      # tcp_listener_chunk_size = 1
+      # tcp_listener_buffer_size = 1
+      # tcp_listener_mem_buf_limit = 10
+
+    # The following settings are "undocumented", we don't recommend uncommenting them unless directed by Microsoft.
+    # They increase the maximum stdout/stderr log collection rate but will also cause higher cpu/memory usage.
+    ## Ref for more details about Ignore_Older -  https://docs.fluentbit.io/manual/v/1.7/pipeline/inputs/tail
+    # [agent_settings.fbit_config]
+    #   log_flush_interval_secs = "1"                 # default value is 15
+    #   tail_mem_buf_limit_megabytes = "10"           # default value is 10
+    #   tail_buf_chunksize_megabytes = "1"            # default value is 32kb (comment out this line for default)
+    #   tail_buf_maxsize_megabytes = "1"              # defautl value is 32kb (comment out this line for default)
+    #   tail_ignore_older = "5m"                      # default value same as fluent-bit default i.e.0m
+
     [agent_settings.health_model]
         enabled = true

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -79,7 +79,7 @@ Using a security agent that is container-aware and can operate from within the c
    # [Combined this takes about eight minutes.]
    az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE               && \
    az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                       && \
-   az acr import --source docker.io/weaveworks/kured:1.12.0 -t quarantine/weaveworks/kured:1.12.0 -n $ACR_NAME_QUARANTINE                       && \
+   az acr import --source docker.io/weaveworks/kured:1.12.0 -t quarantine/weaveworks/kured:1.12.0 -n $ACR_NAME_QUARANTINE                     && \
    az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.1.2 -t quarantine/ingress-nginx/controller:v1.1.2 -n $ACR_NAME_QUARANTINE    && \
    az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1 -t quarantine/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME_QUARANTINE
    ```
@@ -113,7 +113,7 @@ Using a security agent that is container-aware and can operate from within the c
    # [Combined this takes about eight minutes.]
    az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME                 && \
    az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                         && \
-   az acr import --source quarantine/weaveworks/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/weaveworks/kured:1.12.0 -n $ACR_NAME                         && \
+   az acr import --source quarantine/weaveworks/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/weaveworks/kured:1.12.0 -n $ACR_NAME                       && \
    az acr import --source quarantine/ingress-nginx/controller:v1.1.2 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.1.2 -n $ACR_NAME       && \
    az acr import --source quarantine/jettech/kube-webhook-certgen:v1.1.1 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME
    ```

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -79,7 +79,7 @@ Using a security agent that is container-aware and can operate from within the c
    # [Combined this takes about eight minutes.]
    az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE               && \
    az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                       && \
-   az acr import --source docker.io/weaveworks/kured:1.9.2 -t quarantine/weaveworks/kured:1.9.2 -n $ACR_NAME_QUARANTINE                       && \
+   az acr import --source docker.io/weaveworks/kured:1.12.0 -t quarantine/weaveworks/kured:1.12.0 -n $ACR_NAME_QUARANTINE                       && \
    az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.1.2 -t quarantine/ingress-nginx/controller:v1.1.2 -n $ACR_NAME_QUARANTINE    && \
    az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1 -t quarantine/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME_QUARANTINE
    ```
@@ -113,7 +113,7 @@ Using a security agent that is container-aware and can operate from within the c
    # [Combined this takes about eight minutes.]
    az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME                 && \
    az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                         && \
-   az acr import --source quarantine/weaveworks/kured:1.9.2 -r $ACR_NAME_QUARANTINE -t live/weaveworks/kured:1.9.2 -n $ACR_NAME                         && \
+   az acr import --source quarantine/weaveworks/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/weaveworks/kured:1.12.0 -n $ACR_NAME                         && \
    az acr import --source quarantine/ingress-nginx/controller:v1.1.2 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.1.2 -n $ACR_NAME       && \
    az acr import --source quarantine/jettech/kube-webhook-certgen:v1.1.1 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME
    ```
@@ -155,7 +155,7 @@ Once web traffic hits Azure Application Gateway (deployed in a future step), pub
 1. Import the AKS ingress controller's certificate.
 
    You currently cannot import certificates into Key Vault directly via ARM templates. As such, post deployment of our bootstrapping resources (which includes Key Vault), you need to upload your ingress controller's wildcard certificate to Key Vault. This is the `.pem` file you created on a prior page. Your ingress controller will authenticate to Key Vault (via its workload identity) and use this certificate as its default TLS certificate, presenting exclusively to your Azure Application Gateway.
-   
+
    _As an alternative, this import process could be done with [`deploymentScripts` within the ARM template](https://github.com/Azure/bicep/discussions/8457#discussioncomment-3712980). Use whatever certificate management process your organization and compliance mandates._
 
    ```bash

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -79,7 +79,7 @@ Using a security agent that is container-aware and can operate from within the c
    # [Combined this takes about eight minutes.]
    az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE               && \
    az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                       && \
-   az acr import --source docker.io/weaveworks/kured:1.12.0 -t quarantine/weaveworks/kured:1.12.0 -n $ACR_NAME_QUARANTINE                     && \
+   az acr import --source ghcr.io/kubereboot/kured:1.12.0 -t quarantine/kubereboot/kured:1.12.0 -n $ACR_NAME_QUARANTINE                       && \
    az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.1.2 -t quarantine/ingress-nginx/controller:v1.1.2 -n $ACR_NAME_QUARANTINE    && \
    az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1 -t quarantine/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME_QUARANTINE
    ```
@@ -113,7 +113,7 @@ Using a security agent that is container-aware and can operate from within the c
    # [Combined this takes about eight minutes.]
    az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME                 && \
    az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                         && \
-   az acr import --source quarantine/weaveworks/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/weaveworks/kured:1.12.0 -n $ACR_NAME                       && \
+   az acr import --source quarantine/kubereboot/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/kubereboot/kured:1.12.0 -n $ACR_NAME                       && \
    az acr import --source quarantine/ingress-nginx/controller:v1.1.2 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.1.2 -n $ACR_NAME       && \
    az acr import --source quarantine/jettech/kube-webhook-certgen:v1.1.1 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME
    ```

--- a/docs/deploy/14-validation-logs.md
+++ b/docs/deploy/14-validation-logs.md
@@ -111,8 +111,9 @@ AzureDiagnostics
 The example workload uses the standard dotnet logger interface, which are captured in `ContainerLogs` in Azure Monitor. You could also include additional logging and telemetry frameworks in your workload, such as Application Insights. Execute the following query to view application logs.
 
 ```kusto
-ContainerLog
-| where Image contains "chain-api"
+ContainerLogV2
+| where ContainerName contains "microservice"
+| where PodNamespace in ("a00095-i", "a0005-o")
 | order by TimeGenerated desc
 ```
 
@@ -121,18 +122,20 @@ ContainerLog
 Azure policy definitions sync with your cluster about once every 15 minutes. To see when they sync you can execute the following query.
 
 ```kusto
-ContainerLog
-| where Image contains "policy-kubernetes-addon"
-| where LogEntry contains "Syncing policies with cluster"
+ContainerLogV2
+| where ContainerName has "azure-policy"
+| where PodNamespace has "kube-system"
+| where LogMessage contains "Syncing policies with cluster"
 | order by TimeGenerated desc
 ```
 
 And audit results will be sent to Azure Policy about once every 30 minutes. To see when they sync you can execute the following query.
 
 ```kusto
-ContainerLog
-| where Image contains "policy-kubernetes-addon"
-| where LogEntry contains "Sending audit result"
+ContainerLogV2
+| where ContainerName has "azure-policy"
+| where PodNamespace has "kube-system"
+| where LogMessage contains "Sending audit result"
 | order by TimeGenerated desc
 ```
 


### PR DESCRIPTION
closes partially: #23809 

## WHY

we want to keep every oss in-cluster up to date and align manifests with upstream in this case with baseline template.

## WHAT Changed?

- Updated kured to latest version (1.9.2 -> 1.12.0) and synced yaml manifests with upstream
- Updated Azure Monitor's configuration to be synced with upstream

## HOW to Test?

clone the repo and follow the instructions. After provisioning the AKS regulated cluster it should be running kured 1.12.0 and azm configuration should be similar to the aks baseline. 

this has been tested e-2-e

![image](https://user-images.githubusercontent.com/158487/218591814-33fba49a-7888-4bf9-bf17-d4b329861722.png)
![image](https://user-images.githubusercontent.com/158487/218597044-59515df8-9b0e-45ed-8225-6f05b40adc01.png)
