### PR TITLE
feat (in-cluster infra): [upgrade oss] bump nginx to 1.5.1

### DIFF
--- a/cluster-manifests/ingress-nginx/deployment.yaml
+++ b/cluster-manifests/ingress-nginx/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -16,6 +18,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
@@ -32,6 +36,8 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -43,6 +49,13 @@ rules:
   - pods
   - secrets
   - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
   verbs:
   - list
   - watch
@@ -89,6 +102,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -96,6 +117,8 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -113,6 +136,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -152,6 +177,14 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses/status
   verbs:
   - update
@@ -165,10 +198,10 @@ rules:
   - watch
 - apiGroups:
     - ""
+  resourceNames:
+  - ingress-nginx-leader
   resources:
   - configmaps
-  resourceNames:
-  - ingress-controller-leader
   verbs:
   - get
   - update
@@ -179,12 +212,35 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ingress-nginx-leader
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
     - ""
   resources:
   - events
   verbs:
   - create
   - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -193,6 +249,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -211,6 +269,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -229,9 +289,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: ingress-nginx    
+    app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
   annotations:
@@ -262,6 +324,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
     pci-scope: out-of-scope
   name: ingress-nginx-controller
   namespace: ingress-nginx
@@ -289,7 +353,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: YOUR_ACR.azurecr.io/live/ingress-nginx/controller:v1.1.2
+          image: YOUR_ACR.azurecr.io/live/ingress-nginx/controller:v1.5.1
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -394,6 +458,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -405,6 +471,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   name: ingress-nginx-admission
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io
@@ -437,6 +505,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   namespace: ingress-nginx
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -447,6 +517,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -464,6 +536,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -481,6 +555,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   namespace: ingress-nginx
 rules:
 - apiGroups:
@@ -499,6 +575,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
   namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,6 +595,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
     pci-scope: out-of-scope
   namespace: ingress-nginx
 spec:
@@ -527,11 +607,13 @@ spec:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.5.1
         pci-scope: out-of-scope
     spec:
       containers:
-      - name: create        
-        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v1.1.1
+      - name: create
+        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
         imagePullPolicy: IfNotPresent
         args:
           - create
@@ -570,6 +652,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
     pci-scope: out-of-scope
   namespace: ingress-nginx
 spec:
@@ -580,11 +664,13 @@ spec:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.5.1
         pci-scope: out-of-scope
     spec:
       containers:
       - name: patch
-        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v1.1.1
+        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
         imagePullPolicy: IfNotPresent
         args:
         - patch

--- a/cluster-manifests/ingress-nginx/deployment.yaml
+++ b/cluster-manifests/ingress-nginx/deployment.yaml
@@ -262,7 +262,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
-    aadpodidbinding: podmi-ingress-controller
     pci-scope: out-of-scope
   name: ingress-nginx-controller
   namespace: ingress-nginx
@@ -285,7 +284,6 @@ spec:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: controller
-        aadpodidbinding: podmi-ingress-controller
         pci-scope: out-of-scope
     spec:
       dnsPolicy: ClusterFirst

--- a/cluster-manifests/ingress-nginx/deployment.yaml
+++ b/cluster-manifests/ingress-nginx/deployment.yaml
@@ -613,7 +613,7 @@ spec:
     spec:
       containers:
       - name: create
-        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
+        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
         imagePullPolicy: IfNotPresent
         args:
           - create
@@ -670,7 +670,7 @@ spec:
     spec:
       containers:
       - name: patch
-        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
+        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
         imagePullPolicy: IfNotPresent
         args:
         - patch

--- a/cluster-manifests/ingress-nginx/deployment.yaml
+++ b/cluster-manifests/ingress-nginx/deployment.yaml
@@ -1,3 +1,4 @@
+# Source: https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.6.4/deploy/static/provider/cloud/deploy.yaml
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -7,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -19,7 +20,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
@@ -37,11 +38,11 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx
 rules:
 - apiGroups:
-    - ""
+  - ""
   resources:
   - configmaps
   - endpoints
@@ -60,13 +61,13 @@ rules:
   - list
   - watch
 - apiGroups:
-    - ""
+  - ""
   resources:
   - nodes
   verbs:
   - get
 - apiGroups:
-    - ""
+  - ""
   resources:
   - services
   verbs:
@@ -82,7 +83,7 @@ rules:
   - list
   - watch
 - apiGroups:
-    - ""
+  - ""
   resources:
   - events
   verbs:
@@ -118,7 +119,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -137,18 +138,18 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
 - apiGroups:
-    - ""
+  - ""
   resources:
   - namespaces
   verbs:
   - get
 - apiGroups:
-    - ""
+  - ""
   resources:
   - configmaps
   - pods
@@ -159,17 +160,9 @@ rules:
   - list
   - watch
 - apiGroups:
-    - ""
+  - ""
   resources:
   - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
   verbs:
   - get
   - list
@@ -197,21 +190,6 @@ rules:
   - list
   - watch
 - apiGroups:
-    - ""
-  resourceNames:
-  - ingress-nginx-leader
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-- apiGroups:
-    - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-- apiGroups:
   - coordination.k8s.io
   resourceNames:
   - ingress-nginx-leader
@@ -227,7 +205,7 @@ rules:
   verbs:
   - create
 - apiGroups:
-    - ""
+  - ""
   resources:
   - events
   verbs:
@@ -250,7 +228,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -270,7 +248,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -293,7 +271,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx-controller
   namespace: ingress-nginx
   annotations:
@@ -325,7 +303,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
     pci-scope: out-of-scope
   name: ingress-nginx-controller
   namespace: ingress-nginx
@@ -353,7 +331,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: YOUR_ACR.azurecr.io/live/ingress-nginx/controller:v1.5.1
+          image: YOUR_ACR.azurecr.io/live/ingress-nginx/controller:v1.6.4
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -459,7 +437,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -472,7 +450,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   name: ingress-nginx-admission
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io
@@ -490,7 +468,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:
-      - v1
+    - v1
     clientConfig:
       service:
         namespace: ingress-nginx
@@ -506,7 +484,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   namespace: ingress-nginx
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -518,15 +496,15 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
 rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -537,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -556,11 +534,11 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   namespace: ingress-nginx
 rules:
 - apiGroups:
-    - ""
+  - ""
   resources:
   - secrets
   verbs:
@@ -576,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
   namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -596,7 +574,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
     pci-scope: out-of-scope
   namespace: ingress-nginx
 spec:
@@ -608,12 +586,12 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.5.1
+        app.kubernetes.io/version: 1.6.4
         pci-scope: out-of-scope
     spec:
       containers:
       - name: create
-        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20220916-gd32f8c343
         imagePullPolicy: IfNotPresent
         args:
           - create
@@ -653,7 +631,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.5.1
+    app.kubernetes.io/version: 1.6.4
     pci-scope: out-of-scope
   namespace: ingress-nginx
 spec:
@@ -665,12 +643,12 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.5.1
+        app.kubernetes.io/version: 1.6.4
         pci-scope: out-of-scope
     spec:
       containers:
       - name: patch
-        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+        image: YOUR_ACR.azurecr.io/live/jettech/kube-webhook-certgen:v20220916-gd32f8c343
         imagePullPolicy: IfNotPresent
         args:
         - patch

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -80,8 +80,8 @@ Using a security agent that is container-aware and can operate from within the c
    az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE               && \
    az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                       && \
    az acr import --source ghcr.io/kubereboot/kured:1.12.0 -t quarantine/kubereboot/kured:1.12.0 -n $ACR_NAME_QUARANTINE                       && \
-   az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.1.2 -t quarantine/ingress-nginx/controller:v1.1.2 -n $ACR_NAME_QUARANTINE    && \
-   az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1 -t quarantine/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME_QUARANTINE
+   az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.5.1 -t quarantine/ingress-nginx/controller:v1.5.1 -n $ACR_NAME_QUARANTINE    && \
+   az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -t quarantine/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -n $ACR_NAME_QUARANTINE
    ```
 
    > The above imports account for 100% of the containers that you are actively bringing to the cluster, but not those that come with the AKS service itself nor any of its add-ons or extensions. Those images, outside of your direct control, are all sourced from Microsoft Container Registry's (MCR). While you do not have an affordance to inject yourself in the middle of their distribution to your cluster, you can still pull those images through your inspection process for your own audit and reporting purposes. _All container images that you directly bring to the cluster should pass through your quarantine process._ The _allowed images_ Azure Policy associated with this cluster should be configured to match your specific needs. Be sure to update `allowedContainerImagesRegex` in [`cluster-stamp.json`](../../cluster-stamp.json) to define expected image sources to whatever specificity is manageable for you. Never allow a source that you do not intend to use. For example, if you do not bring Open Service Mesh into your cluster, you can remove the existing allowance for `mcr.microsoft.com` as a valid source of images, leaving just `<your acr instance>/live/` repositories as the only valid source for non-system namespaces.
@@ -114,8 +114,8 @@ Using a security agent that is container-aware and can operate from within the c
    az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME                 && \
    az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                         && \
    az acr import --source quarantine/kubereboot/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/kubereboot/kured:1.12.0 -n $ACR_NAME                       && \
-   az acr import --source quarantine/ingress-nginx/controller:v1.1.2 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.1.2 -n $ACR_NAME       && \
-   az acr import --source quarantine/jettech/kube-webhook-certgen:v1.1.1 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v1.1.1 -n $ACR_NAME
+   az acr import --source quarantine/ingress-nginx/controller:v1.5.1 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.5.1 -n $ACR_NAME       && \
+   az acr import --source quarantine/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -n $ACR_NAME
    ```
 
 1. Trigger quarantine violation. _Optional._

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -81,7 +81,7 @@ Using a security agent that is container-aware and can operate from within the c
    az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                       && \
    az acr import --source ghcr.io/kubereboot/kured:1.12.0 -t quarantine/kubereboot/kured:1.12.0 -n $ACR_NAME_QUARANTINE                       && \
    az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.5.1 -t quarantine/ingress-nginx/controller:v1.5.1 -n $ACR_NAME_QUARANTINE    && \
-   az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -t quarantine/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -n $ACR_NAME_QUARANTINE
+   az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -t quarantine/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -n $ACR_NAME_QUARANTINE
    ```
 
    > The above imports account for 100% of the containers that you are actively bringing to the cluster, but not those that come with the AKS service itself nor any of its add-ons or extensions. Those images, outside of your direct control, are all sourced from Microsoft Container Registry's (MCR). While you do not have an affordance to inject yourself in the middle of their distribution to your cluster, you can still pull those images through your inspection process for your own audit and reporting purposes. _All container images that you directly bring to the cluster should pass through your quarantine process._ The _allowed images_ Azure Policy associated with this cluster should be configured to match your specific needs. Be sure to update `allowedContainerImagesRegex` in [`cluster-stamp.json`](../../cluster-stamp.json) to define expected image sources to whatever specificity is manageable for you. Never allow a source that you do not intend to use. For example, if you do not bring Open Service Mesh into your cluster, you can remove the existing allowance for `mcr.microsoft.com` as a valid source of images, leaving just `<your acr instance>/live/` repositories as the only valid source for non-system namespaces.
@@ -115,7 +115,7 @@ Using a security agent that is container-aware and can operate from within the c
    az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                         && \
    az acr import --source quarantine/kubereboot/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/kubereboot/kured:1.12.0 -n $ACR_NAME                       && \
    az acr import --source quarantine/ingress-nginx/controller:v1.5.1 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.5.1 -n $ACR_NAME       && \
-   az acr import --source quarantine/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f -n $ACR_NAME
+   az acr import --source quarantine/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -n $ACR_NAME
    ```
 
 1. Trigger quarantine violation. _Optional._

--- a/docs/deploy/09-pre-cluster-stamp.md
+++ b/docs/deploy/09-pre-cluster-stamp.md
@@ -77,11 +77,11 @@ Using a security agent that is container-aware and can operate from within the c
    ACR_NAME_QUARANTINE=$(az deployment group show -g rg-bu0001a0005 -n pre-cluster-stamp --query properties.outputs.quarantineContainerRegistryName.value -o tsv)
 
    # [Combined this takes about eight minutes.]
-   az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE               && \
-   az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                       && \
-   az acr import --source ghcr.io/kubereboot/kured:1.12.0 -t quarantine/kubereboot/kured:1.12.0 -n $ACR_NAME_QUARANTINE                       && \
-   az acr import --source k8s.gcr.io/ingress-nginx/controller:v1.5.1 -t quarantine/ingress-nginx/controller:v1.5.1 -n $ACR_NAME_QUARANTINE    && \
-   az acr import --source k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -t quarantine/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -n $ACR_NAME_QUARANTINE
+   az acr import --source docker.io/falcosecurity/falco:0.29.1 -t quarantine/falcosecurity/falco:0.29.1 -n $ACR_NAME_QUARANTINE                 && \
+   az acr import --source docker.io/library/busybox:1.33.0 -t quarantine/library/busybox:1.33.0 -n $ACR_NAME_QUARANTINE                         && \
+   az acr import --source ghcr.io/kubereboot/kured:1.12.0 -t quarantine/kubereboot/kured:1.12.0 -n $ACR_NAME_QUARANTINE                         && \
+   az acr import --source registry.k8s.io/ingress-nginx/controller:v1.6.4 -t quarantine/ingress-nginx/controller:v1.6.4 -n $ACR_NAME_QUARANTINE && \
+   az acr import --source registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343 -t quarantine/jettech/kube-webhook-certgen:v20220916-gd32f8c343 -n $ACR_NAME_QUARANTINE
    ```
 
    > The above imports account for 100% of the containers that you are actively bringing to the cluster, but not those that come with the AKS service itself nor any of its add-ons or extensions. Those images, outside of your direct control, are all sourced from Microsoft Container Registry's (MCR). While you do not have an affordance to inject yourself in the middle of their distribution to your cluster, you can still pull those images through your inspection process for your own audit and reporting purposes. _All container images that you directly bring to the cluster should pass through your quarantine process._ The _allowed images_ Azure Policy associated with this cluster should be configured to match your specific needs. Be sure to update `allowedContainerImagesRegex` in [`cluster-stamp.json`](../../cluster-stamp.json) to define expected image sources to whatever specificity is manageable for you. Never allow a source that you do not intend to use. For example, if you do not bring Open Service Mesh into your cluster, you can remove the existing allowance for `mcr.microsoft.com` as a valid source of images, leaving just `<your acr instance>/live/` repositories as the only valid source for non-system namespaces.
@@ -111,11 +111,11 @@ Using a security agent that is container-aware and can operate from within the c
    ACR_NAME=$(az deployment group show -g rg-bu0001a0005 -n pre-cluster-stamp --query properties.outputs.containerRegistryName.value -o tsv)
 
    # [Combined this takes about eight minutes.]
-   az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME                 && \
-   az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                         && \
-   az acr import --source quarantine/kubereboot/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/kubereboot/kured:1.12.0 -n $ACR_NAME                       && \
-   az acr import --source quarantine/ingress-nginx/controller:v1.5.1 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.5.1 -n $ACR_NAME       && \
-   az acr import --source quarantine/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 -n $ACR_NAME
+   az acr import --source quarantine/falcosecurity/falco:0.29.1 -r $ACR_NAME_QUARANTINE -t live/falcosecurity/falco:0.29.1 -n $ACR_NAME           && \
+   az acr import --source quarantine/library/busybox:1.33.0 -r $ACR_NAME_QUARANTINE -t live/library/busybox:1.33.0 -n $ACR_NAME                   && \
+   az acr import --source quarantine/kubereboot/kured:1.12.0 -r $ACR_NAME_QUARANTINE -t live/kubereboot/kured:1.12.0 -n $ACR_NAME                 && \
+   az acr import --source quarantine/ingress-nginx/controller:v1.6.4 -r $ACR_NAME_QUARANTINE -t live/ingress-nginx/controller:v1.6.4 -n $ACR_NAME && \
+   az acr import --source quarantine/jettech/kube-webhook-certgen:v20220916-gd32f8c343 -r $ACR_NAME_QUARANTINE -t live/jettech/kube-webhook-certgen:v20220916-gd32f8c343 -n $ACR_NAME
    ```
 
 1. Trigger quarantine violation. _Optional._


### PR DESCRIPTION
closes partially: #23809 

## WHY

we want to keep every oss in-cluster up to date and align manifests with upstream in this case with [nginx quickstart repo](https://github.com/kubernetes/ingress-nginx/blob/a00cf624b7ef43f44278bf1ce1114e0de663104e/docs/deploy/index.md#quick-start).

## WHAT Changed?

- Updated nginx to latest version (1.1.2 -> 1.5.1) and synced yaml manifests with upstream
- minor bug fix 8d0c3442256f767ab0fac582d87e3ac91b30fe07 from #66

## HOW to Test?

clone the repo and follow the instructions. After provisioning the AKS regulated cluster it should be running nginx 1.5.1. 

Tested e2e:

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/158487/220133585-1cfd7f0d-b271-4327-9d41-c976e442f068.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/158487/220133055-42af4547-4e7d-4aa6-af77-d47a44e00f49.png">

