### PR TITLE
patch (deploy): [docs] revert ingress var name to its original shorter naming convention

### DIFF
--- a/docs/deploy/02-ca-certificates.md
+++ b/docs/deploy/02-ca-certificates.md
@@ -46,7 +46,7 @@ To support end-to-end TLS encryption, the following TLS certificates are procure
    :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the public certificate (as `.crt` or `.cer`) to be Base64 encoded for proper storage in Key Vault later.
 
    ```bash
-   AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat ingress-internal-aks-ingress-contoso-com-tls.crt | base64 | tr -d '\n')
+   INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat ingress-internal-aks-ingress-contoso-com-tls.crt | base64 | tr -d '\n')
    ```
 
 ### Next step


### PR DESCRIPTION
Revert "bug fix - align cert env var name with cluster expected param"

This reverts commit e5cf4427a30fdbff522b69c32348a0f88206543a.