### PR TITLE
feat (cluster): [version] bump aks regulater cluster to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Finally, this implementation uses a small, custom application as an example work
 
 #### Azure platform
 
-* AKS v1.25
+* AKS v1.26
   * System and User [node pool separation](https://learn.microsoft.com/azure/aks/use-system-pools)
   * [AKS-managed Azure AD](https://learn.microsoft.com/azure/aks/managed-aad)
   * Managed Identities for kubelet and control plane

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -54,7 +54,7 @@ param gitOpsBootstrappingRepoBranch string = 'main'
 
 /*** VARIABLES ***/
 
-var kubernetesVersion = '1.25.2'
+var kubernetesVersion = '1.26.0'
 
 var subRgUniqueString = uniqueString('aks', subscription().subscriptionId, resourceGroup().id)
 var clusterName = 'aks-${subRgUniqueString}'

--- a/docs/deploy/11-validate-cluster-access-and-bootstrapping.md
+++ b/docs/deploy/11-validate-cluster-access-and-bootstrapping.md
@@ -71,13 +71,13 @@ Your cluster was deployed with Azure Policy and the Flux GitOps extension. You'l
 
    ```output
    NAME                                  STATUS   ROLES   AGE   VERSION
-   aks-npinscope01-26621167-vmss000000   Ready    agent   20m   v1.25.x
-   aks-npinscope01-26621167-vmss000001   Ready    agent   20m   v1.25.x
-   aks-npooscope01-26621167-vmss000000   Ready    agent   20m   v1.25.x
-   aks-npooscope01-26621167-vmss000001   Ready    agent   20m   v1.25.x
-   aks-npsystem-26621167-vmss000000      Ready    agent   20m   v1.25.x
-   aks-npsystem-26621167-vmss000001      Ready    agent   20m   v1.25.x
-   aks-npsystem-26621167-vmss000002      Ready    agent   20m   v1.25.x
+   aks-npinscope01-26621167-vmss000000   Ready    agent   20m   v1.26.x
+   aks-npinscope01-26621167-vmss000001   Ready    agent   20m   v1.26.x
+   aks-npooscope01-26621167-vmss000000   Ready    agent   20m   v1.26.x
+   aks-npooscope01-26621167-vmss000001   Ready    agent   20m   v1.26.x
+   aks-npsystem-26621167-vmss000000      Ready    agent   20m   v1.26.x
+   aks-npsystem-26621167-vmss000001      Ready    agent   20m   v1.26.x
+   aks-npsystem-26621167-vmss000002      Ready    agent   20m   v1.26.x
    ```
 
    > :watch: The access tokens obtained in the prior two steps are subject to a Microsoft Identity Platform TTL (e.g. six hours). If your `az` or `kubectl` commands start erroring out after hours of usage with a message related to permission/authorization, you'll need to re-execute the `az login` and `az aks get-credentials` (overwriting your context) to refresh those tokens.


### PR DESCRIPTION
closes: #23808

## WHY

We want to keep our AKS clusters version fresh upgrading to latest and testing it in our regulated one.

## WHAT Changes?

- bumped kubernetes version to `1.26`

## HOW to Test?

You can clone and follow the steps to deploy the cluster and all works as expected and cluster version is `1.26`

  



<img width="667" alt="image" src="https://user-images.githubusercontent.com/158487/223822063-261b1dad-ff06-4412-91b3-d788e4ee92ac.png">
